### PR TITLE
Update routeMultiple -> routeMultipleLong for getProperty

### DIFF
--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -171,10 +171,10 @@ void RAD::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			enableGvaSupport = gva != 0;
 
 		KernelPatcher::RouteRequest requests[] {
-			KernelPatcher::RouteRequest("__ZN15IORegistryEntry11setPropertyEPKcPvj", wrapSetProperty, orgSetProperty),
-			KernelPatcher::RouteRequest("__ZNK15IORegistryEntry11getPropertyEPKc", wrapGetProperty, orgGetProperty),
+		    KernelPatcher::RouteRequest("__ZN15IORegistryEntry11setPropertyEPKcPvj", wrapSetProperty, orgSetProperty),
+		    KernelPatcher::RouteRequest("__ZNK15IORegistryEntry11getPropertyEPKc", wrapGetProperty, orgGetProperty),
 		};
-		patcher.routeMultipleLong(requests, 2); // hoping this works, away from home atm
+		patcher.routeMultipleLong(KernelPatcher::KernelID, requests, arrsize(requests));
 
 		if (useCustomAgdpDecision && info->firmwareVendor == DeviceInfo::FirmwareVendor::Apple)
 			useCustomAgdpDecision = false;

--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -174,7 +174,7 @@ void RAD::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			KernelPatcher::RouteRequest("__ZN15IORegistryEntry11setPropertyEPKcPvj", wrapSetProperty, orgSetProperty),
 			KernelPatcher::RouteRequest("__ZNK15IORegistryEntry11getPropertyEPKc", wrapGetProperty, orgGetProperty),
 		};
-		patcher.routeMultiple(KernelPatcher::KernelID, requests);
+		patcher.routeMultipleLong(requests, 2); // hoping this works, away from home atm
 
 		if (useCustomAgdpDecision && info->firmwareVendor == DeviceInfo::FirmwareVendor::Apple)
 			useCustomAgdpDecision = false;


### PR DESCRIPTION
So, this probably was not expected to happen any time soon, or practically ever but I suddenly have the need to wrap/reroute ``__ZNK15IORegistryEntry11getPropertyEPKc`` which at the moment, would conflict with WhateverGreen's implementation. I would prefer to not ship a custom WEG that has this line updated to allow multiple plug-ins to wrap/reroute this function. The usage in question is in an IORegistry cleansing module, that reports back to specific Procs with specific details about the system such as ``manufacturer`` with custom string ``Apple Inc.`` and so on.

This fixes the following kernel panic when a separate plug-in wishes to reroute the same function:

```
panic(cpu 1 caller 0xffffff8013931fbe): Lilu   patcher: @ previous plugin had short jump type on a multiroute function, this is not allowed

Panicked task 0xffffffa51f1b59b0: 120 threads: pid 0: kernel_task
Backtrace (CPU 1), panicked thread: 0xffffffa51eabeb40, Frame : Return Address
0xfffffffefb96f4c0 : 0xffffff800fde8351 mach_kernel : _handle_debugger_trap + 0x4c1
0xfffffffefb96f510 : 0xffffff800ff5611c mach_kernel : _kdp_i386_trap + 0x11c
0xfffffffefb96f550 : 0xffffff800ff459e3 mach_kernel : _kernel_trap + 0x763
0xfffffffefb96f620 : 0xffffff800fd7d971 mach_kernel : _return_from_trap + 0xc1
0xfffffffefb96f640 : 0xffffff800fde8647 mach_kernel : _DebuggerTrapWithState + 0x67
0xfffffffefb96f740 : 0xffffff800fde7ce2 mach_kernel : _panic_trap_to_debugger + 0x1e2
...
```

I've ensured that my own plug-in does not interfere with WEG, and vice-versa. I would prefer to not ship a custom WEG, if possible.