### PR TITLE
wait for IOGraphicsFamily to load before patching AMDSupport on Tahoe

### DIFF
--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -41,6 +41,8 @@ static const char *idRadeonX6000New {"com.apple.kext.AMDRadeonX6000"};
 static const char *idRadeonX3000Old {"com.apple.AMDRadeonX3000"};
 static const char *idRadeonX4000Old {"com.apple.AMDRadeonX4000"};
 
+static KernelPatcher::KextInfo kextIOGraphicsFamily
+{ "com.apple.iokit.IOGraphicsFamily", nullptr, 0, {}, {}, KernelPatcher::KextInfo::Unloaded };
 static KernelPatcher::KextInfo kextRadeonFramebuffer
 { "com.apple.kext.AMDFramebuffer", pathFramebuffer, arrsize(pathFramebuffer), {}, {}, KernelPatcher::KextInfo::Unloaded };
 static KernelPatcher::KextInfo kextRadeonLegacyFramebuffer
@@ -79,6 +81,16 @@ static const char *powerGatingFlags[] {
 	"CAIL_DisableAcpPowerGating",
 	"CAIL_DisableSAMUPowerGating"
 };
+
+/**
+ *  This function will be called by Lilu ONLY when IOGraphicsFamily has loaded.
+ *  Its only job is to then activate our patches for AMDSupport.
+ */
+static void onIOGraphicsLoad(void *user, KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	if (RAD *rad = static_cast<RAD *>(user)) {
+		lilu.onKextLoadForce(&kextRadeonSupport);
+	}
+}
 
 RAD *RAD::callbackRAD;
 
@@ -119,7 +131,13 @@ void RAD::init(bool enableNavi10Bkl) {
 	forceCodecInfo = checkKernelArgument("-radcodec");
 
 	// To support overriding connectors and -radvesa mode we need to patch AMDSupport.
-	lilu.onKextLoadForce(&kextRadeonSupport);
+    if (getKernelVersion() >= KernelVersion::Tahoe) {
+    	// For macOS Tahoe (Kernel 25) and newer, we must wait for IOGraphicsFamily to load before patching AMDSupport.
+        lilu.onKextLoad(&kextIOGraphicsFamily, 1, onIOGraphicsLoad, this);
+    } else {
+        lilu.onKextLoadForce(&kextRadeonSupport);
+    }
+
 	// Mojave dropped legacy GPU support (5xxx and 6xxx).
 	if (getKernelVersion() < KernelVersion::Mojave)
 		lilu.onKextLoadForce(&kextRadeonLegacySupport);


### PR DESCRIPTION
Since Tahoe Developer Beta 1, WhateverGreen causes an Invalid Opcode (6) kernel panic when booting into recoveryOS, and during the update phases. This has been resolved by simply ensuring that IOGraphicsFamily has loaded prior to patching AmdSupport.kext, and I've wrapped the appropriate call to only run on Tahoe, to ensure that users of Sonoma and below, are not affected, without having to test.

Although, I personally have tested on Sonoma 15.6 and Tahoe DB1, and have gotten a confirmed boot on both recoveryOS and during the update phases.